### PR TITLE
`Conv` does have `padding_mode` attribute

### DIFF
--- a/Wang2017Multimodal/mt.py
+++ b/Wang2017Multimodal/mt.py
@@ -74,9 +74,9 @@ class MT(nn.Module):
         self.refine_subnet.load_state_dict(refine_subnet)
 
         # for error 'conv2d has no attribute padding_mode'
-        for m in self.modules():
-            if 'Conv' in str(type(m)):
-                setattr(m, 'padding_mode', 'none')
+        # for m in self.modules():
+        #     if 'Conv' in str(type(m)):
+        #         setattr(m, 'padding_mode', 'none')
 
     def forward(self, x):
         # x = F.interpolate(x, 256, mode='bilinear', align_corners=True)


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/Users/rahulbhalley/Desktop/URST/Wang2017Multimodal/test.py", line 137, in <module>
    style_transfer_thumbnail(image, save_path=os.path.join(args.outf, "original_result.jpg"),
  File "/Users/rahulbhalley/Desktop/URST/Wang2017Multimodal/test.py", line 56, in style_transfer_thumbnail
    stylized_thumb = net.forward(image_thumb)
  File "/Users/rahulbhalley/Desktop/URST/Wang2017Multimodal/mt.py", line 83, in forward
    y1, _ = self.style_subnet(x)
  File "/opt/homebrew/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1194, in _call_impl
    return forward_call(*input, **kwargs)
  File "/Users/rahulbhalley/Desktop/URST/Wang2017Multimodal/style_subnet.py", line 77, in forward
    with torch.no_grad(): x_l = self.togray(x.clone())
  File "/opt/homebrew/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1194, in _call_impl
    return forward_call(*input, **kwargs)
  File "/opt/homebrew/lib/python3.9/site-packages/torch/nn/modules/conv.py", line 463, in forward
    return self._conv_forward(input, self.weight, self.bias)
  File "/opt/homebrew/lib/python3.9/site-packages/torch/nn/modules/conv.py", line 456, in _conv_forward
    return F.conv2d(F.pad(input, self._reversed_padding_repeated_twice, mode=self.padding_mode),
NotImplementedError: Unrecognised padding mode none
```

From PyTorch's [Conv2d](https://pytorch.org/docs/stable/generated/torch.nn.Conv2d.html#torch.nn.Conv2d) doc:

- `padding: 0`
- `padding_mode: 'zeros'`